### PR TITLE
feat: add Belgian eID support

### DIFF
--- a/include/electronic-id/electronic-id.hpp
+++ b/include/electronic-id/electronic-id.hpp
@@ -47,6 +47,7 @@ public:
         LatEID,
         LitEID,
         HrvEID,
+        BelEID,
     };
 
     virtual ~ElectronicID() = default;

--- a/include/electronic-id/enums.hpp
+++ b/include/electronic-id/enums.hpp
@@ -38,13 +38,9 @@ public:
     CertificateType() = default;
     constexpr CertificateType(const CertificateTypeEnum _value) : value(_value) {}
 
-    bool isAuthentication() const
-    {
-        if (value == NONE) {
-            throw std::logic_error("CertificateType::isAuthentication(): value cannot be NONE");
-        }
-        return value == AUTHENTICATION;
-    }
+    bool isAuthentication() const { return value == AUTHENTICATION; }
+
+    bool isSigning() const { return value == SIGNING; }
 
     operator std::string() const;
 

--- a/src/electronic-id.cpp
+++ b/src/electronic-id.cpp
@@ -99,6 +99,12 @@ const std::map<byte_vector, ElectronicIDConstructor> SUPPORTED_ATRS = {
          return std::make_unique<Pkcs11ElectronicID>(std::move(card),
                                                      Pkcs11ElectronicIDType::HrvEID);
      }},
+    // BelEid
+    {{0x3b, 0x98, 0x13, 0x40, 0x0a, 0xa5, 0x03, 0x01, 0x01, 0x01, 0xad, 0x13, 0x11},
+     [](SmartCard::ptr&& card) {
+         return std::make_unique<Pkcs11ElectronicID>(std::move(card),
+                                                     Pkcs11ElectronicIDType::BelEID);
+     }},
 };
 
 inline std::string byteVectorToHexString(const byte_vector& bytes)

--- a/src/electronic-ids/pkcs11/Pkcs11ElectronicID.hpp
+++ b/src/electronic-ids/pkcs11/Pkcs11ElectronicID.hpp
@@ -34,6 +34,7 @@ enum class Pkcs11ElectronicIDType {
     LitEIDv2,
     LitEIDv3,
     HrvEID,
+    BelEID,
 };
 
 struct Pkcs11ElectronicIDModule


### PR DESCRIPTION
Refs: https://github.com/web-eid/libelectronic-id/issues/30

Now I'm not sure whether you accept pull requests or not from third-party collaborators (feel free to just close it, if not), but I'm hoping that this PR has at least some informational value and serves as a good starting point for when you start implementing the Belgian eID.

Please note that:
https://github.com/web-eid/libelectronic-id/pull/31/files#diff-1d1e9d13402083e3e4cfef76240e0afa5c7dbd2c004dbd19153acbe3703be28dL169-L175

https://github.com/web-eid/libelectronic-id/pull/31/files#diff-5e815893cc922d5085482de88a00dc7775fb3201555be4efaa224115aebb80dbL43-R50

^ I changed these parts to explicitly check for the signing certificate. The reason for this is that the Belgian eID card has 4 certs so we can't assume that if the cert is not for authentication then it must always be for signing. In this specific case, the old code threw at the Root CA cert at enums.hpp  `if (value == NONE)` check and caused the whole program to abort. However, for Root CA cert it makse sense to have a value of NONE, since it is neither a signing nor authentication cert.



Signed-off-by: Mats-Joonas Kulla <matsjoonas@gmail.com>