### PR TITLE
Feature: Select supported cards based on AID

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/libpcsc-cpp"]
 	path = lib/libpcsc-cpp
-	url = https://github.com/Muzosh/libpcsc-cpp.git
+	url = https://github.com/web-eid/libpcsc-cpp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/libpcsc-cpp"]
 	path = lib/libpcsc-cpp
-	url = ../libpcsc-cpp
+	url = https://github.com/Muzosh/libpcsc-cpp.git

--- a/include/electronic-id/electronic-id.hpp
+++ b/include/electronic-id/electronic-id.hpp
@@ -112,7 +112,7 @@ private:
     ElectronicID& operator=(ElectronicID&&) = delete;
 };
 
-bool isCardSupported(const pcsc_cpp::byte_vector& atr);
+bool isCardATRSupported(const pcsc_cpp::byte_vector& atr);
 
 ElectronicID::ptr getElectronicID(const pcsc_cpp::Reader& reader);
 

--- a/include/electronic-id/electronic-id.hpp
+++ b/include/electronic-id/electronic-id.hpp
@@ -114,7 +114,8 @@ private:
 
 bool isCardATRSupported(const pcsc_cpp::byte_vector& atr);
 
-ElectronicID::ptr getElectronicID(const pcsc_cpp::Reader& reader);
+ElectronicID::ptr getElectronicIDbyATR(const pcsc_cpp::Reader& reader);
+ElectronicID::ptr getElectronicIDbyAID(const byte_vector aid, const pcsc_cpp::SmartCard::ptr card);
 
 /** Aggregates reader and electronic ID objects for communicating with and inspecting the eID card.
  */

--- a/include/electronic-id/electronic-id.hpp
+++ b/include/electronic-id/electronic-id.hpp
@@ -113,9 +113,10 @@ private:
 };
 
 bool isCardATRSupported(const pcsc_cpp::byte_vector& atr);
+bool isCardAIDSupported(const pcsc_cpp::SmartCard::ptr& card);
 
 ElectronicID::ptr getElectronicIDbyATR(const pcsc_cpp::Reader& reader);
-ElectronicID::ptr getElectronicIDbyAID(const byte_vector aid, const pcsc_cpp::SmartCard::ptr card);
+ElectronicID::ptr getElectronicIDbyAID(const byte_vector aid, pcsc_cpp::SmartCard::ptr card);
 
 /** Aggregates reader and electronic ID objects for communicating with and inspecting the eID card.
  */

--- a/include/electronic-id/electronic-id.hpp
+++ b/include/electronic-id/electronic-id.hpp
@@ -113,10 +113,10 @@ private:
 };
 
 bool isCardATRSupported(const pcsc_cpp::byte_vector& atr);
-bool isCardAIDSupported(const pcsc_cpp::SmartCard::ptr& card);
+bool isCardAIDSupported(const pcsc_cpp::SmartCard& card);
 
 ElectronicID::ptr getElectronicIDbyATR(const pcsc_cpp::Reader& reader);
-ElectronicID::ptr getElectronicIDbyAID(const byte_vector aid, pcsc_cpp::SmartCard::ptr card);
+ElectronicID::ptr getElectronicIDbyAID(const pcsc_cpp::byte_vector& aid, pcsc_cpp::SmartCard::ptr card);
 
 /** Aggregates reader and electronic ID objects for communicating with and inspecting the eID card.
  */

--- a/src/availableSupportedCards.cpp
+++ b/src/availableSupportedCards.cpp
@@ -57,7 +57,7 @@ std::vector<CardInfo::ptr> availableSupportedCards()
                 continue;
             }
             seenCard = true;
-            if (isCardSupported(reader.cardAtr)) {
+            if (isCardATRSupported(reader.cardAtr) || isCardAIDSupported(reader.)) {
                 cards.push_back(connectToCard(reader));
             }
         }

--- a/src/availableSupportedCards.cpp
+++ b/src/availableSupportedCards.cpp
@@ -37,9 +37,9 @@ inline CardInfo::ptr connectToEIDByATR(const pcsc_cpp::Reader& reader)
     return std::make_shared<CardInfo>(reader, eid);
 }
 
-inline CardInfo::ptr connectToEIDByAID(const pcsc_cpp::Reader& reader, const pcsc_cpp::SmartCard::ptr card)
+inline CardInfo::ptr connectToEIDByAID(const pcsc_cpp::Reader& reader, pcsc_cpp::SmartCard::ptr card)
 {
-    auto eid = getElectronicIDbyAID(card);
+    auto eid = getElectronicIDbyAID(reader.cardAtr, card);
     return std::make_shared<CardInfo>(reader, eid);
 }
 
@@ -66,10 +66,10 @@ std::vector<CardInfo::ptr> availableSupportedCards()
             if (isCardATRSupported(reader.cardAtr)) {
                 cards.push_back(connectToEIDByATR(reader));
             } else {
-                pcsc_cpp::SmartCard::ptr card = reader.connectToCard();
+                pcsc_cpp::SmartCard::ptr card_ptr = reader.connectToCard();
 
-                if (isCardAIDSupported(card)) {
-                    cards.push_back(connectToEIDByAID(reader, card));
+                if (isCardAIDSupported(card_ptr)) {
+                    cards.push_back(connectToEIDByAID(reader, card_ptr));
                 }
             }
         }

--- a/src/availableSupportedCards.cpp
+++ b/src/availableSupportedCards.cpp
@@ -57,7 +57,7 @@ std::vector<CardInfo::ptr> availableSupportedCards()
                 continue;
             }
             seenCard = true;
-            if (isCardATRSupported(reader.cardAtr) || isCardAIDSupported(reader.)) {
+            if (isCardATRSupported(reader.cardAtr) || isCardAIDSupported(reader)) {
                 cards.push_back(connectToCard(reader));
             }
         }

--- a/src/availableSupportedCards.cpp
+++ b/src/availableSupportedCards.cpp
@@ -37,9 +37,10 @@ inline CardInfo::ptr connectToEIDByATR(const pcsc_cpp::Reader& reader)
     return std::make_shared<CardInfo>(reader, eid);
 }
 
-inline CardInfo::ptr connectToEIDByAID(const pcsc_cpp::Reader& reader, pcsc_cpp::SmartCard::ptr card)
+inline CardInfo::ptr connectToEIDByAID(const pcsc_cpp::Reader& reader,
+                                       pcsc_cpp::SmartCard::ptr card)
 {
-    auto eid = getElectronicIDbyAID(reader.cardAtr, card);
+    auto eid = getElectronicIDbyAID(reader.cardAtr, std::move(card));
     return std::make_shared<CardInfo>(reader, eid);
 }
 
@@ -68,8 +69,8 @@ std::vector<CardInfo::ptr> availableSupportedCards()
             } else {
                 pcsc_cpp::SmartCard::ptr card_ptr = reader.connectToCard();
 
-                if (isCardAIDSupported(card_ptr)) {
-                    cards.push_back(connectToEIDByAID(reader, card_ptr));
+                if (isCardAIDSupported(*card_ptr)) {
+                    cards.push_back(connectToEIDByAID(reader, std::move(card_ptr)));
                 }
             }
         }

--- a/src/electronic-id.cpp
+++ b/src/electronic-id.cpp
@@ -143,7 +143,12 @@ const auto SUPPORTED_ALGORITHMS = std::map<std::string, HashAlgorithm> {
 namespace electronic_id
 {
 
-bool isCardSupported(const pcsc_cpp::byte_vector& atr)
+bool isCardATRSupported(const pcsc_cpp::byte_vector& atr)
+{
+    return SUPPORTED_ATRS.count(atr);
+}
+
+bool isCardAIDSupported(const pcsc_cpp::byte_vector& atr)
 {
     return SUPPORTED_ATRS.count(atr);
 }
@@ -154,7 +159,7 @@ ElectronicID::ptr getElectronicID(const pcsc_cpp::Reader& reader)
         const auto& eidConstructor = SUPPORTED_ATRS.at(reader.cardAtr);
         return eidConstructor(reader.connectToCard());
     } catch (const std::out_of_range&) {
-        // It should be verified that the card is supported with isCardSupported() before
+        // It should be verified that the card is supported with isCardATRSupported() before
         // calling getElectronicID(), so it is a programming error if out_of_range occurs here.
         THROW(ProgrammingError,
               "Card with ATR '" + byteVectorToHexString(reader.cardAtr) + "' is not supported");

--- a/src/electronic-id.cpp
+++ b/src/electronic-id.cpp
@@ -118,6 +118,13 @@ const std::map<byte_vector, ElectronicIDConstructor> SUPPORTED_ATRS = {
      }},
 };
 
+const std::map<byte_vector, ElectronicIDConstructor> SUPPORTED_AIDS = {
+    // EXAMPLE:
+    // PIV FIPS  201-3
+    // {{0xa0, 0x00, 0x00, 0x03, 0x08, 0x00, 0x00, 0x10, 0x00, 0x01, 0x00},
+    //  [](SmartCard::ptr&& card) { return std::make_unique<PIV>(std::move(card)); }},
+};
+
 inline std::string byteVectorToHexString(const byte_vector& bytes)
 {
     std::ostringstream hexStringBuilder;
@@ -148,9 +155,10 @@ bool isCardATRSupported(const pcsc_cpp::byte_vector& atr)
     return SUPPORTED_ATRS.count(atr);
 }
 
-bool isCardAIDSupported(const pcsc_cpp::byte_vector& atr)
+bool isCardAIDSupported(const pcsc_cpp::Reader& reader)
 {
-    return SUPPORTED_ATRS.count(atr);
+    
+    return SUPPORTED_AIDS.count(atr);
 }
 
 ElectronicID::ptr getElectronicID(const pcsc_cpp::Reader& reader)

--- a/src/electronic-id.cpp
+++ b/src/electronic-id.cpp
@@ -155,14 +155,13 @@ bool isCardATRSupported(const pcsc_cpp::byte_vector& atr)
     return SUPPORTED_ATRS.count(atr);
 }
 
-bool isCardAIDSupported(const pcsc_cpp::SmartCard::ptr card_ptr)
+bool isCardAIDSupported(const pcsc_cpp::SmartCard& card)
 {
     for (const auto& aid_eid_pair : SUPPORTED_AIDS) {
         const pcsc_cpp::CommandApdu SELECT_AID_HEADER {0x00, 0xA4, 0x04, 0x00};
         const auto select_aid = pcsc_cpp::CommandApdu {SELECT_AID_HEADER, aid_eid_pair.first};
 
         pcsc_cpp::ResponseApdu response;
-        pcsc_cpp::SmartCard& card = *card_ptr;
         response = card.transmit(select_aid);
 
         if (response.isOK()) {
@@ -190,7 +189,7 @@ ElectronicID::ptr getElectronicIDbyAID(const byte_vector& aid, pcsc_cpp::SmartCa
 {
     try {
         const auto& eidConstructor = SUPPORTED_AIDS.at(aid);
-        return eidConstructor(card);
+        return eidConstructor(std::move(card));
     } catch (const std::out_of_range&) {
         // It should be verified that the card is supported with isCardAIDSupported() before
         // calling getElectronicIDbyAID(), so it is a programming error if out_of_range occurs here.

--- a/src/electronic-id.cpp
+++ b/src/electronic-id.cpp
@@ -155,13 +155,14 @@ bool isCardATRSupported(const pcsc_cpp::byte_vector& atr)
     return SUPPORTED_ATRS.count(atr);
 }
 
-bool isCardAIDSupported(const pcsc_cpp::SmartCard& card)
+bool isCardAIDSupported(const pcsc_cpp::SmartCard::ptr card_ptr)
 {
     for (const auto& aid_eid_pair : SUPPORTED_AIDS) {
         const pcsc_cpp::CommandApdu SELECT_AID_HEADER {0x00, 0xA4, 0x04, 0x00};
         const auto select_aid = pcsc_cpp::CommandApdu {SELECT_AID_HEADER, aid_eid_pair.first};
 
         pcsc_cpp::ResponseApdu response;
+        pcsc_cpp::SmartCard& card = *card_ptr;
         response = card.transmit(select_aid);
 
         if (response.isOK()) {
@@ -185,7 +186,7 @@ ElectronicID::ptr getElectronicIDbyATR(const pcsc_cpp::Reader& reader)
     }
 }
 
-ElectronicID::ptr getElectronicIDbyAID(const byte_vector aid, const pcsc_cpp::SmartCard::ptr card)
+ElectronicID::ptr getElectronicIDbyAID(const byte_vector& aid, pcsc_cpp::SmartCard::ptr card)
 {
     try {
         const auto& eidConstructor = SUPPORTED_AIDS.at(aid);

--- a/src/electronic-ids/pkcs11/Pkcs11ElectronicID.cpp
+++ b/src/electronic-ids/pkcs11/Pkcs11ElectronicID.cpp
@@ -114,7 +114,7 @@ std::string belgianPkcs11ModulePath()
 const std::map<electronic_id::Pkcs11ElectronicIDType, electronic_id::Pkcs11ElectronicIDModule>
     SUPPORTED_PKCS11_MODULES = {
         // EstEIDIDEMIAV1 configuration is here only for testing,
-        // it is not enabled in getElectronicID().
+        // it is not enabled in getElectronicIDbyATR().
         {electronic_id::Pkcs11ElectronicIDType::EstEIDIDEMIAV1,
          {
              "EstEID IDEMIA v1 (PKCS#11)"s, // name


### PR DESCRIPTION
I have created this draft PR to layout very basic changes for Web-eID to be able to work with smartcards based on application AID installed on the card, not the ATR itself. Related to #38 