### PR TITLE
Prevent double-free by zeroing library handle after closing

### DIFF
--- a/src/electronic-ids/pkcs11/PKCS11CardManager.hpp
+++ b/src/electronic-ids/pkcs11/PKCS11CardManager.hpp
@@ -109,8 +109,10 @@ public:
         }
 #ifdef _WIN32
         FreeLibrary(library);
+        library = 0;
 #else
         dlclose(library);
+        library = nullptr;
 #endif
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/web-eid/.github/blob/master/CONTRIBUTING.md!
-->
WE2-911

Signed-off-by: Mart Somermaa <mrts@users.noreply.github.com>