### PR TITLE
Add backwards-compatible support for the new Croatian PKCS11 module (for v2.6.1 RC3)

### DIFF
--- a/src/electronic-ids/pkcs11/Pkcs11ElectronicID.cpp
+++ b/src/electronic-ids/pkcs11/Pkcs11ElectronicID.cpp
@@ -72,11 +72,26 @@ inline fs::path lithuanianPKCS11ModulePath()
 inline fs::path croatianPkcs11ModulePath()
 {
 #ifdef _WIN32
-    return programFilesPath() / L"AKD/eID Middleware/pkcs11/AkdEidPkcs11_64.dll";
+    fs::path certiliaPath =
+        programFilesPath() / L"AKD/Certilia Middleware/pkcs11/AkdEidPkcs11_64.dll";
+    fs::path eidPath = programFilesPath() / L"AKD/eID Middleware/pkcs11/AkdEidPkcs11_64.dll";
+    return fs::exists(certiliaPath) ? certiliaPath : eidPath;
 #elif defined __APPLE__
-    return "/Library/AKD/eID Middleware/pkcs11/libEidPkcs11.so"; // NB! Not tested.
+    // The driver provider installs the library to /usr/local/lib/pkcs11, but
+    // sandboxed applications cannot access /usr/local/ due to macOS restrictions.
+    // To make the solution work, the library libEidPkcs11.dylib and License.bin must be
+    // copied to /Library/AKD/pkcs11, which is accessible in sandboxed environments:
+    //
+    //  sudo mkdir -p /Library/AKD/pkcs11
+    //  sudo cp -a /usr/local/lib/pkcs11/{libEidPkcs11.dylib,License.bin} /Library/AKD/pkcs11/
+    //
+    // This workaround is required until the driver provider addresses the issue.
+    // NB! This is not tested.
+    return "/Library/AKD/pkcs11/libEidPkcs11.dylib";
 #else // Linux
-    return "/usr/lib/akd/eidmiddleware/pkcs11/libEidPkcs11.so";
+    fs::path certiliaPath = "/usr/lib/akd/certiliamiddleware/pkcs11/libEidPkcs11.so";
+    fs::path eidPath = "/usr/lib/akd/eidmiddleware/pkcs11/libEidPkcs11.so";
+    return fs::exists(certiliaPath) ? certiliaPath : eidPath;
 #endif
 }
 


### PR DESCRIPTION
WE2-1017

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/web-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Mart Somermaa <mrts@users.noreply.github.com>

See

- https://github.com/web-eid/libelectronic-id/pull/85
- https://github.com/web-eid/libelectronic-id/issues/86

This is a clean implementation for the new v2.6.x branch.