### PR TITLE
No error with two cards connected when one uses PKCS#11 and the other is unsupported (for v2.6.1 RC3)

### DIFF
--- a/include/electronic-id/electronic-id.hpp
+++ b/include/electronic-id/electronic-id.hpp
@@ -178,6 +178,12 @@ class Pkcs11Error : public Error
     using Error::Error;
 };
 
+/** The PKCS#11 library and/or slot does not recognize the token in the slot. */
+class Pkcs11TokenNotRecognized : public Pkcs11Error
+{
+    using Pkcs11Error::Pkcs11Error;
+};
+
 /** Smart card was not present in its slot at the time that a PKCS#11 function was invoked. */
 class Pkcs11TokenNotPresent : public Error
 {

--- a/src/electronic-ids/pkcs11/PKCS11CardManager.hpp
+++ b/src/electronic-ids/pkcs11/PKCS11CardManager.hpp
@@ -148,6 +148,7 @@ public:
             try {
                 C(GetTokenInfo, slotID, &tokenInfo);
             } catch (const Pkcs11Error&) {
+                // TODO: log a warning with the exception message.
                 continue;
             }
             CK_SESSION_HANDLE session = 0;
@@ -296,7 +297,7 @@ private:
         case CKR_PIN_LOCKED:
             throw VerifyPinFailed(VerifyPinFailed::Status::PIN_BLOCKED);
         case CKR_TOKEN_NOT_RECOGNIZED:
-            THROW_WITH_CALLER_INFO(SmartCardChangeRequiredError,
+            THROW_WITH_CALLER_INFO(Pkcs11TokenNotRecognized,
                                    std::string(apiFunction) + ": token not recognized", file, line,
                                    function);
         case CKR_TOKEN_NOT_PRESENT:


### PR DESCRIPTION
Ignore `CKR_TOKEN_NOT_RECOGNIZED`  errors during `C_GetTokenInfo()`.

WE2-1044

<!--
Thank you for your pull request.

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX'
(without quotes) in the commit message.

Please update Signed-off-by info and read the common contributing guidelines
before you continue https://github.com/web-eid/.github/blob/master/CONTRIBUTING.md!
-->

Signed-off-by: Mart Somermaa <mrts@users.noreply.github.com>