### PR TITLE
Undo constexpr for operator== with std::vector for Ubuntu 22.04

### DIFF
--- a/src/electronic-id.cpp
+++ b/src/electronic-id.cpp
@@ -103,7 +103,7 @@ struct MaskedATREntry
     {
     }
 
-    constexpr bool operator==(const byte_vector& atr) const
+    bool operator==(const byte_vector& atr) const
     {
         return std::equal(atr.cbegin(), atr.cend(), pattern.cbegin(), pattern.cend(),
                           [mask_ptr = mask.data()](byte_type a, byte_type p) mutable {


### PR DESCRIPTION
WE2-1204

Signed-off-by: Mart Somermaa <mrts@users.noreply.github.com>
